### PR TITLE
Changes marker icons, adds infrastructure for bike racks

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jest": "^20.0.4",
     "jest-cli": "^20.0.4",
     "knex": "^0.13.0",
+    "leaflet": "^1.2.0",
     "leaflet-control-geocoder": "^1.5.5",
     "leaflet-routing-machine": "^3.2.5",
     "leaflet.marker.pin": "^1.3.0",

--- a/src/client/components/App.vue
+++ b/src/client/components/App.vue
@@ -15,7 +15,6 @@
     },
     methods: {
       detectmob() {
-        console.log(window.innerWidth)
         if( navigator.userAgent.match(/Android/i)
           || navigator.userAgent.match(/webOS/i)
           || navigator.userAgent.match(/iPhone/i)
@@ -27,7 +26,6 @@
           } else {
             this.$store.commit('SET_MOBILE', false)
           }
-        console.log('mobile', this.$store.state.mobile)
       },
     }
   }

--- a/src/client/components/areaReporting.vue
+++ b/src/client/components/areaReporting.vue
@@ -52,7 +52,6 @@
       return {};
     },
     mounted() {
-      console.log(this)
     },
     methods: {
       toReportType: (reportType, other) => {

--- a/src/client/components/leafletMap.vue
+++ b/src/client/components/leafletMap.vue
@@ -25,6 +25,7 @@
         trailsLayer: null,
         fixitsLayer: null,
         kiosksLayer: null,
+        // parkingLayer: null,
         kiosksClose: [],
         notifiedKiosks: [],
         isNotified: false
@@ -35,6 +36,7 @@
       this.$store.dispatch('LOAD_KIOSKS')
       this.$store.dispatch('LOAD_TRAILS')
       this.$store.dispatch('LOAD_FIXITS')
+      // this.$store.dispatch('LOAD_PARKING')
     },
 
     mounted() {
@@ -65,6 +67,9 @@
       fixits: function() {
         mLayers.fixitMarkers(this)
       },
+        // parking: function() {
+        //     mLayers.parkingMarkers(this)
+        // },
       kiosks: function() {
         mLayers.kioskMarkers(this)
       },
@@ -76,6 +81,10 @@
       location: function() {
           return this.$store.getters.location
       },
+        // parking: function() {
+        //     return this.$store.getters.parking
+        // }
+        // ,
       kiosks: function() {
           return this.$store.getters.kiosks
       },
@@ -112,11 +121,12 @@
         this.$data.trailsLayer = L.geoJSON()
         this.$data.fixitsLayer = L.layerGroup('')
         this.$data.kiosksLayer = L.layerGroup('')
+        // this.$data.parkingLayer = L.layerGroup('')
         //end layers
 
         //map creation
         var mymap = L.map('mapid', {
-            center: [51.505, -0.09],
+            center: [30.269, -97.743],
             zoom: 13,
             layers: [
             // this.$data.mainDarkLayer,
@@ -124,6 +134,7 @@
             this.$data.trailsLayer,
             this.$data.fixitsLayer,
             this.$data.kiosksLayer,
+            // this.$data.parkingLayer,
             ]
         });
         this.$data.map = mymap
@@ -131,24 +142,20 @@
         L.Control.geocoder({position: "topleft"}).addTo(this.map);
 
         //map location
-        // mLocation.locate()
 
         mLocation.locate(this, mymap)
 
         function getHandlerForFeature(feat) {  // A function...
           return function(ev) {   // ...that returns a function...
-            console.log(feat);  // ...that has a closure over the value.
           }
         }
 
         function click (e) {
           this.closePanels()
-          console.log('One, ah ah ah');
         }
 
         function doubleClick (e) {
-          console.log('TWO, AH AH AH');
-          let position = [e.latlng.lat, e.latlng.lng];
+          let position = [e.latlng.lat, e.latlng.lng]
           var reports = document.getElementsByClassName('reporting');
           reports[0].setAttribute('id', 'selected');
           reports[0].setAttribute('data', position);

--- a/src/client/components/leafletMethods/methLayers.js
+++ b/src/client/components/leafletMethods/methLayers.js
@@ -8,7 +8,7 @@ export default {
       const lon = chunk[11][2]
       const name = chunk[8]
       const address = JSON.parse(chunk[11][0]).address
-        const marker = L.marker([lat, lon], { icon: fixitIcon })
+      const marker = L.marker([lat, lon], { icon: fixitIcon })
       marker.bindPopup(`<b>${name} Fixit Station</b><br>${address}`)
       context.$data.fixitsLayer.addLayer(marker)
     })
@@ -19,23 +19,23 @@ export default {
         const address = chunk[9]
         const lat = chunk[11]
         const lon = chunk[12]
-          const marker = L.marker([lat, lon], { icon: kioskIcon })
+        const marker = L.marker([lat, lon], { icon: kioskIcon })
         marker.bindPopup(`${address} Bicycle Kiosk`)
         context.$data.kiosksLayer.addLayer(marker)
       }
     })
   },
-    parkingMarkers(context) {
-        context.parking.forEach((chunk) => {
-            console.log(chunk[9])
-            const address = chunk[9]
-            const lat = chunk[11]
-            const lon = chunk[12]
-            const marker = L.marker([lat, lon], { icon: parkingIcon })
-            marker.bindPopup(`${address} Bicycle Rack`)
-            context.$data.parkingLayer.addLayer(marker)
-        })
-    },
+  parkingMarkers(context) {
+    context.parking.forEach((chunk) => {
+      console.log(chunk[9])
+      const address = chunk[9]
+      const lat = chunk[11]
+      const lon = chunk[12]
+      const marker = L.marker([lat, lon], { icon: rackIcon })
+      marker.bindPopup(`${address} Bicycle Rack`)
+      context.$data.parkingLayer.addLayer(marker)
+    })
+  },
   addTrails(context) {
     context.$data.trailsLayer.addData(context.trails)
   },

--- a/src/client/components/leafletMethods/methLayers.js
+++ b/src/client/components/leafletMethods/methLayers.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-undef */
+import { fixitIcon, kioskIcon, rackIcon } from '../mapIcons'
+
 export default {
   fixitMarkers: (context) => {
     context.fixits.forEach((chunk) => {
@@ -6,7 +8,7 @@ export default {
       const lon = chunk[11][2]
       const name = chunk[8]
       const address = JSON.parse(chunk[11][0]).address
-      const marker = L.marker([lat, lon])
+        const marker = L.marker([lat, lon], { icon: fixitIcon })
       marker.bindPopup(`<b>${name} Fixit Station</b><br>${address}`)
       context.$data.fixitsLayer.addLayer(marker)
     })
@@ -17,12 +19,23 @@ export default {
         const address = chunk[9]
         const lat = chunk[11]
         const lon = chunk[12]
-        const marker = L.marker([lat, lon])
+          const marker = L.marker([lat, lon], { icon: kioskIcon })
         marker.bindPopup(`${address} Bicycle Kiosk`)
         context.$data.kiosksLayer.addLayer(marker)
       }
     })
   },
+    parkingMarkers(context) {
+        context.parking.forEach((chunk) => {
+            console.log(chunk[9])
+            const address = chunk[9]
+            const lat = chunk[11]
+            const lon = chunk[12]
+            const marker = L.marker([lat, lon], { icon: parkingIcon })
+            marker.bindPopup(`${address} Bicycle Rack`)
+            context.$data.parkingLayer.addLayer(marker)
+        })
+    },
   addTrails(context) {
     context.$data.trailsLayer.addData(context.trails)
   },

--- a/src/client/components/mapIcons.js
+++ b/src/client/components/mapIcons.js
@@ -1,20 +1,22 @@
+import * as L from 'leaflet'
+
 const fixitSVG = '../../static/repair-bicycle.svg'
 const kioskSVG = '../../static/rental-bicycle.svg'
 const rackSVG = '../../static/parking-bicycle.svg'
 
 const fixitIcon = L.icon({
-    iconUrl: fixitSVG,
-    iconSize: [38, 95],
+  iconUrl: fixitSVG,
+  iconSize: [38, 95],
 })
 const kioskIcon = L.icon({
-    iconUrl: kioskSVG,
-    iconSize: [38, 95],
+  iconUrl: kioskSVG,
+  iconSize: [38, 95],
 })
 
 const rackIcon = L.icon({
-    iconUrl: rackSVG,
-    iconSize: [38, 95],
+  iconUrl: rackSVG,
+  iconSize: [38, 95],
 })
 
 
-export {fixitIcon, kioskIcon, rackIcon}
+export { fixitIcon, kioskIcon, rackIcon }

--- a/src/client/components/mapIcons.js
+++ b/src/client/components/mapIcons.js
@@ -1,0 +1,20 @@
+const fixitSVG = '../../static/repair-bicycle.svg'
+const kioskSVG = '../../static/rental-bicycle.svg'
+const rackSVG = '../../static/parking-bicycle.svg'
+
+const fixitIcon = L.icon({
+    iconUrl: fixitSVG,
+    iconSize: [38, 95],
+})
+const kioskIcon = L.icon({
+    iconUrl: kioskSVG,
+    iconSize: [38, 95],
+})
+
+const rackIcon = L.icon({
+    iconUrl: rackSVG,
+    iconSize: [38, 95],
+})
+
+
+export {fixitIcon, kioskIcon, rackIcon}

--- a/src/client/vuex/store.js
+++ b/src/client/vuex/store.js
@@ -20,6 +20,7 @@ const state = {
   kiosks: [],
   fixits: [],
   trails: [],
+  parking: [],
   location: null
 }
 
@@ -64,7 +65,15 @@ const actions = {
       })
   },
 
-  LOAD_KIOSKS: ({ commit }) => {
+  LOAD_PARKING: ({ commit }) => {
+        axios.get('/racks').then((response) => {
+            commit('SET_PARKING', { parking: response.data.data })
+        }, (err) => {
+            console.log(err)
+        })
+    },
+
+ LOAD_KIOSKS: ({ commit }) => {
     axios.get('/kiosks').then((response) => {
       commit('SET_KIOSKS', { kiosks: response.data.data })
     }, (err) => {
@@ -121,6 +130,9 @@ const mutations = {
   SET_KIOSKS(state, { kiosks }) {
     state.kiosks = kiosks
   },
+    SET_PARKING(state, { parking }) {
+        state.parking = parking
+    },
   SET_FIXITS(state, { fixits }) {
     state.fixits = fixits
   },
@@ -133,6 +145,7 @@ const getters = {
   location: state => state.location,
   kiosks: state => state.kiosks,
   fixits: state => state.fixits,
+  parking: state => state.parking,
   trails: state => state.trails,
   // authfailAt: state => state.viewSignIn || !state.signedIn,
 }

--- a/src/client/vuex/store.js
+++ b/src/client/vuex/store.js
@@ -66,14 +66,14 @@ const actions = {
   },
 
   LOAD_PARKING: ({ commit }) => {
-        axios.get('/racks').then((response) => {
-            commit('SET_PARKING', { parking: response.data.data })
-        }, (err) => {
-            console.log(err)
-        })
-    },
+    axios.get('/racks').then((response) => {
+      commit('SET_PARKING', { parking: response.data.data })
+    }, (err) => {
+      console.log(err)
+    })
+  },
 
- LOAD_KIOSKS: ({ commit }) => {
+  LOAD_KIOSKS: ({ commit }) => {
     axios.get('/kiosks').then((response) => {
       commit('SET_KIOSKS', { kiosks: response.data.data })
     }, (err) => {
@@ -130,9 +130,9 @@ const mutations = {
   SET_KIOSKS(state, { kiosks }) {
     state.kiosks = kiosks
   },
-    SET_PARKING(state, { parking }) {
-        state.parking = parking
-    },
+  SET_PARKING(state, { parking }) {
+    state.parking = parking
+  },
   SET_FIXITS(state, { fixits }) {
     state.fixits = fixits
   },

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -48,7 +48,7 @@ server.route({
           // add user if it doesn't exist
           knex('users').insert({ email: request.payload.email, phone: request.payload.phone, password: request.payload.password })
             .then((num) => {
-            // search for user to return
+              // search for user to return
               knex('users').where({ id: num[0] })
                 .then((user) => {
                   reply(user)
@@ -71,13 +71,13 @@ server.route({
 })
 
 server.route({
-    method: 'GET',
-    path: '/kiosks',
-    handler: {
-        file: {
-            path: path.join(__dirname, '../client/data/bCycleKiosks.json')
-        }
+  method: 'GET',
+  path: '/kiosks',
+  handler: {
+    file: {
+      path: path.join(__dirname, '../client/data/bCycleKiosks.json')
     }
+  }
 })
 
 server.route({

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -71,11 +71,21 @@ server.route({
 })
 
 server.route({
+    method: 'GET',
+    path: '/kiosks',
+    handler: {
+        file: {
+            path: path.join(__dirname, '../client/data/bCycleKiosks.json')
+        }
+    }
+})
+
+server.route({
   method: 'GET',
-  path: '/kiosks',
+  path: '/racks',
   handler: {
     file: {
-      path: path.join(__dirname, '../client/data/bCycleKiosks.json')
+      path: path.join(__dirname, '../client/data/bikeRacks.json')
     }
   }
 })


### PR DESCRIPTION
**Changes marker icons, adds infrastructure for bike racks**
Because the bike rack data is not workable, we don't load that data from the
back end or instantiate the parking layer. Probably the best path forward is to
allow users to input bike rack locations, and store the reported lat/lon in the database.

[Closes #117]

**Linter fixes, adds leaflet to package.json**